### PR TITLE
[Feat] SearchField 컴포넌트 구현 및 책 검색 페이지 구현

### DIFF
--- a/src/app/(afterLogin)/books/_components/Book.tsx
+++ b/src/app/(afterLogin)/books/_components/Book.tsx
@@ -14,16 +14,14 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { BookType } from '@/mocks/user';
+import { BookSearchResponse } from '@/types/aladin.type';
 
 interface Props {
-  book: BookType;
+  book: BookSearchResponse;
 }
 
 export default function Book({ book }: Props) {
-  const { title, author, isbn, page, readPage, cover, rank } = book;
-
-  const progress = Math.round((readPage / page) * 10000) / 100;
+  const { title, author, isbn13: isbn, cover, customerReviewRank } = book;
 
   // const handleSearch = async () => {
   //   if (!isbn) return;
@@ -47,16 +45,15 @@ export default function Book({ book }: Props) {
         </CardHeader>
         <CardContent className="flex grow flex-col justify-between gap-4 px-4 py-6">
           {/* <span className="text-sm underline text-zinc-400 underline-offset-4">{genre}</span> */}
-          <ProgressCard description="진행률" value={progress} />
         </CardContent>
         <CardFooter className="px-4">
           <div className="flex w-full items-center justify-between">
-            <StarScore value={rank} />
+            <div className="flex items-center gap-2">
+              <StarScore value={customerReviewRank} />
+              <span>{customerReviewRank}</span>
+            </div>
             <div className="flex items-center gap-1.5 border border-orange-500/20 bg-orange-500/10 px-2 py-1">
               <Users size={12} className="text-brand" />
-              <span className="text-label text-brand font-mono">
-                {book.readPage}
-              </span>
             </div>
           </div>
         </CardFooter>

--- a/src/app/(afterLogin)/books/_components/Book.tsx
+++ b/src/app/(afterLogin)/books/_components/Book.tsx
@@ -4,7 +4,6 @@ import { Users } from 'lucide-react';
 import Link from 'next/link';
 
 import { ImageWithFallback } from '@/components/ImageWithFallback';
-import ProgressCard from '@/components/ProgressCard';
 import StarScore from '@/components/StarScore';
 import {
   Card,

--- a/src/app/(afterLogin)/books/_components/BookContainer.tsx
+++ b/src/app/(afterLogin)/books/_components/BookContainer.tsx
@@ -1,13 +1,16 @@
 import { userData } from '@/mocks/user';
 
 import Book from './Book';
+import { BookListResponse, BookSearchResponse } from '@/types/aladin.type';
 
-export default function BookContainer() {
-  const { books } = userData;
+interface Props {
+  books?: BookListResponse;
+}
 
+export default function BookContainer({ books }: Props) {
   return (
     <div className="grid grid-cols-2 gap-x-6 gap-y-12 sm:grid-cols-3 lg:grid-cols-4">
-      {books.map((book) => (
+      {books?.item.map((book) => (
         <Book key={book.isbn} book={book} />
       ))}
     </div>

--- a/src/app/(afterLogin)/books/_components/BookContainer.tsx
+++ b/src/app/(afterLogin)/books/_components/BookContainer.tsx
@@ -1,7 +1,7 @@
 import { userData } from '@/mocks/user';
+import { BookListResponse, BookSearchResponse } from '@/types/aladin.type';
 
 import Book from './Book';
-import { BookListResponse, BookSearchResponse } from '@/types/aladin.type';
 
 interface Props {
   books?: BookListResponse;

--- a/src/app/(afterLogin)/books/page.tsx
+++ b/src/app/(afterLogin)/books/page.tsx
@@ -1,9 +1,12 @@
+import SearchField from '@/components/SearchField';
 import BookContainer from './_components/BookContainer';
 
 export default function LibraryPage() {
   return (
     <main className="m-auto w-[920px] p-4">
-      <h1>Library Page</h1>
+      <div className="flex justify-center pb-5">
+        <SearchField placeholder="책 제목, 저자, 장르를 입력해주세요..." />
+      </div>
       <BookContainer />
     </main>
   );

--- a/src/app/(afterLogin)/books/page.tsx
+++ b/src/app/(afterLogin)/books/page.tsx
@@ -1,4 +1,5 @@
 import SearchField from '@/components/SearchField';
+
 import BookContainer from './_components/BookContainer';
 
 export default function LibraryPage() {

--- a/src/app/(afterLogin)/books/search/page.tsx
+++ b/src/app/(afterLogin)/books/search/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import SearchField from '@/components/SearchField';
+import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
+import { fetchBookSearchProxy } from '@/lib/aladin.api';
+import BookContainer from '../_components/BookContainer';
+
+export default function LibraryPage() {
+  const searchParams = useSearchParams();
+  const query = searchParams.get('keyword');
+
+  if (!query || query.length < 2) return null;
+
+  const {} = useQuery({
+    queryKey: ['books', query],
+    queryFn: async () => fetchBookSearchProxy({ query }),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+
+  return (
+    <main className="m-auto w-[920px] p-4">
+      <div className="flex justify-center pb-5">
+        <SearchField placeholder="책 제목, 저자, 장르를 입력해주세요..." />
+      </div>
+      <BookContainer />
+    </main>
+  );
+}

--- a/src/app/(afterLogin)/books/search/page.tsx
+++ b/src/app/(afterLogin)/books/search/page.tsx
@@ -8,7 +8,7 @@ import { fetchBookSearchProxy } from '@/lib/aladin.api';
 
 import BookContainer from '../_components/BookContainer';
 
-export default function LibraryPage() {
+export default function SearchBookPage() {
   const searchParams = useSearchParams();
   const query = searchParams.get('keyword');
   const isEnabledQuery = !!query && query.length > 1;

--- a/src/app/(afterLogin)/books/search/page.tsx
+++ b/src/app/(afterLogin)/books/search/page.tsx
@@ -1,22 +1,24 @@
 'use client';
 
-import SearchField from '@/components/SearchField';
 import { useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
+
+import SearchField from '@/components/SearchField';
 import { fetchBookSearchProxy } from '@/lib/aladin.api';
+
 import BookContainer from '../_components/BookContainer';
 
 export default function LibraryPage() {
   const searchParams = useSearchParams();
   const query = searchParams.get('keyword');
+  const isEnabledQuery = !!query && query.length > 1;
 
-  if (!query || query.length < 2) return null;
-
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['books', query],
-    queryFn: async () => fetchBookSearchProxy({ query }),
+    queryFn: async () => fetchBookSearchProxy({ query: query || '' }),
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
+    enabled: isEnabledQuery,
   });
 
   return (
@@ -24,7 +26,8 @@ export default function LibraryPage() {
       <div className="flex justify-center pb-5">
         <SearchField placeholder="책 제목, 저자, 장르를 입력해주세요..." />
       </div>
-      {data && <BookContainer books={data} />}
+      {isLoading && <div>로딩중...</div>}
+      {isEnabledQuery && !isLoading && data && <BookContainer books={data} />}
     </main>
   );
 }

--- a/src/app/(afterLogin)/books/search/page.tsx
+++ b/src/app/(afterLogin)/books/search/page.tsx
@@ -12,7 +12,7 @@ export default function LibraryPage() {
 
   if (!query || query.length < 2) return null;
 
-  const {} = useQuery({
+  const { data } = useQuery({
     queryKey: ['books', query],
     queryFn: async () => fetchBookSearchProxy({ query }),
     staleTime: 5 * 60 * 1000,
@@ -24,7 +24,7 @@ export default function LibraryPage() {
       <div className="flex justify-center pb-5">
         <SearchField placeholder="책 제목, 저자, 장르를 입력해주세요..." />
       </div>
-      <BookContainer />
+      {data && <BookContainer books={data} />}
     </main>
   );
 }

--- a/src/app/(afterLogin)/home/_components/ProfileCard.tsx
+++ b/src/app/(afterLogin)/home/_components/ProfileCard.tsx
@@ -19,7 +19,7 @@ export default async function ProfileCard() {
   const profileImageSrc = user?.image || DefaultProfile.src;
 
   return (
-    <div className="bg-background-primary border-border-primary flex flex-col gap-2 rounded-xs border p-6">
+    <div className="bg-background-secondary border-border-primary flex flex-col gap-2 rounded-xs border p-6">
       {/* SECTION - header */}
       <div className="flex items-center justify-between">
         <span className="text-text-neutral-secondary text-xs leading-none">

--- a/src/app/(afterLogin)/home/_components/ProfileCard.tsx
+++ b/src/app/(afterLogin)/home/_components/ProfileCard.tsx
@@ -1,13 +1,14 @@
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { ArrowUpRight, AtSignIcon, Calendar } from 'lucide-react';
+import Image from 'next/image';
+
+import DefaultProfile from '@/../public/default-profile.png';
 
 import { auth } from '@/auth';
 import { Button } from '@/components/ui/button';
-import DefaultProfile from '@/../public/default-profile.png';
 
 import 'dayjs/locale/ko';
-import Image from 'next/image';
 
 dayjs.locale('ko');
 dayjs.extend(relativeTime);

--- a/src/app/(afterLogin)/home/page.tsx
+++ b/src/app/(afterLogin)/home/page.tsx
@@ -2,15 +2,21 @@ import BookMark from '@/components/BookMark';
 import PageContainer from '@/components/PageContainer';
 
 import ProfileCard from './_components/ProfileCard';
+import SearchField from '@/components/SearchField';
 
 export default function HomePage() {
   return (
     <PageContainer as="main">
+      <div className="flex justify-center pb-5">
+        <SearchField />
+      </div>
       <div className="flex gap-4">
-        <div className="grow">
+        <div className="flex grow flex-col">
           <ProfileCard />
         </div>
-        <BookMark />
+        <div className="flex flex-col">
+          <BookMark />
+        </div>
       </div>
     </PageContainer>
   );

--- a/src/app/(afterLogin)/home/page.tsx
+++ b/src/app/(afterLogin)/home/page.tsx
@@ -8,10 +8,7 @@ export default function HomePage() {
   return (
     <PageContainer as="main">
       <div className="flex justify-center pb-5">
-        <SearchField
-          placeholder="책 제목, 저자, 장르를 입력해주세요..."
-          offset={2}
-        />
+        <SearchField placeholder="책 제목, 저자, 장르를 입력해주세요..." />
       </div>
       <div className="flex gap-4">
         <div className="flex grow flex-col">

--- a/src/app/(afterLogin)/home/page.tsx
+++ b/src/app/(afterLogin)/home/page.tsx
@@ -8,7 +8,10 @@ export default function HomePage() {
   return (
     <PageContainer as="main">
       <div className="flex justify-center pb-5">
-        <SearchField />
+        <SearchField
+          placeholder="책 제목, 저자, 장르를 입력해주세요..."
+          offset={2}
+        />
       </div>
       <div className="flex gap-4">
         <div className="flex grow flex-col">

--- a/src/app/(afterLogin)/home/page.tsx
+++ b/src/app/(afterLogin)/home/page.tsx
@@ -1,8 +1,8 @@
 import BookMark from '@/components/BookMark';
 import PageContainer from '@/components/PageContainer';
+import SearchField from '@/components/SearchField';
 
 import ProfileCard from './_components/ProfileCard';
-import SearchField from '@/components/SearchField';
 
 export default function HomePage() {
   return (

--- a/src/app/api/open/book/aladin/search/route.ts
+++ b/src/app/api/open/book/aladin/search/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('query');
+  const queryType = searchParams.get('queryType') ?? 'Keyword';
+  const start = searchParams.get('start') ?? '1';
+  const maxResults = searchParams.get('maxResults') ?? '10';
+
+  if (!query || query.length < 2) {
+    return NextResponse.json(
+      { error: '검색어를 2글자 이상 입력해주세요.' },
+      { status: 400 },
+    );
+  }
+
+  const ttbKey = process.env.ALADIN_API_TTBKEY;
+
+  if (!ttbKey) {
+    return NextResponse.json(
+      { error: '서버 내부 오류: TTBKey 누락' },
+      { status: 500 },
+    );
+  }
+
+  // 알라딘 API 설정
+  const baseUrl = 'http://www.aladin.co.kr/ttb/api/ItemSearch.aspx';
+  const apiParams = new URLSearchParams({
+    ttbkey: ttbKey,
+    Query: query,
+    QueryType: queryType,
+    ItemIdType: 'ISBN13',
+    Output: 'JS',
+    Version: '20131101',
+    Cover: 'Big',
+    Start: start,
+    MaxResults: maxResults,
+  });
+
+  try {
+    // 서버에서 알라딘으로 요청 (CORS, 로컬 제한 우회)
+    const response = await fetch(`${baseUrl}?${apiParams.toString()}`);
+
+    if (!response.ok) {
+      throw new Error(`알라딘 API 오류: ${response.status}`);
+    }
+
+    // 알라딘은 JSON을 주지만, 응답 헤더가 텍스트일 수 있어 .json() 대신 텍스트로 받아 파싱 추천
+    // 가끔 끝에 세미콜론(;)이 붙어오는 경우가 있어 제거 처리
+    const textData = await response.text();
+    // 혹시라도 세미콜론이 있으면 제거
+    const cleanData = textData.trim().replace(/;$/, '');
+
+    const data = JSON.parse(cleanData);
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('알라딘 프록시 에러:', error);
+    return NextResponse.json({ error: '알라딘 검색 실패' }, { status: 500 });
+  }
+}

--- a/src/app/api/open/book/aladin/search/route.ts
+++ b/src/app/api/open/book/aladin/search/route.ts
@@ -40,6 +40,7 @@ export async function GET(request: Request) {
   try {
     // 서버에서 알라딘으로 요청 (CORS, 로컬 제한 우회)
     const response = await fetch(`${baseUrl}?${apiParams.toString()}`);
+    console.log(`${baseUrl}?${apiParams.toString()}`);
 
     if (!response.ok) {
       throw new Error(`알라딘 API 오류: ${response.status}`);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,11 +49,15 @@
   /* ---DOKHU Theme--- */
   --color-background-primary: var(--background-primary);
   --color-background-primary-hover: var(--background-primary-hover);
+  --color-background-secondary: var(--background-secondary);
   --color-border-primary: var(--border-primary);
+  --color-border-secondary: var(--border-secondary);
+  --color-text-tertiary: var(--text-tertiary);
   --color-text-neutral-primary: var(--text-neutral-primary);
   --color-text-neutral-secondary: var(--text-neutral-secondary);
   --color-text-neutral-tertiary: var(--text-neutral-tertiary);
   --color-text-brand-tertiary: var(--text-brand-tertiary);
+  --color-icon-primary: var(--icon-primary);
   --color-icon-neutral-primary: var(--icon-neutral-primary);
 }
 
@@ -92,13 +96,17 @@
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   /* ---DOKHU Theme--- */
-  --background-primary: oklch(0.2931 0 0);
+  --background-primary: oklch(0.235 0 0);
   --background-primary-hover: oklch(0.3407 0 0);
+  --background-secondary: oklch(0.2931 0 0);
   --border-primary: oklch(0.3867 0 0);
+  --border-secondary: oklch(0.5624 0 0);
+  --text-tertiary: oklch(0.7668 0 0);
   --text-neutral-primary: oklch(0.9158 0 0);
   --text-neutral-secondary: oklch(0.8483 0 0);
   --text-neutral-tertiary: oklch(0.7636 0 0);
   --text-brand-tertiary: oklch(0.6392 0.1813 41.96);
+  --icon-primary: oklch(100% 0.00011 271.152);
   --icon-neutral-primary: oklch(0.9158 0 0);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,6 +52,7 @@
   --color-background-secondary: var(--background-secondary);
   --color-border-primary: var(--border-primary);
   --color-border-secondary: var(--border-secondary);
+  --color-border-brand-tertiary: var(--border-brand-tertiary);
   --color-text-tertiary: var(--text-tertiary);
   --color-text-neutral-primary: var(--text-neutral-primary);
   --color-text-neutral-secondary: var(--text-neutral-secondary);
@@ -59,6 +60,7 @@
   --color-text-brand-tertiary: var(--text-brand-tertiary);
   --color-icon-primary: var(--icon-primary);
   --color-icon-neutral-primary: var(--icon-neutral-primary);
+  --color-icon-brand-secondary: var(--icon-brand-secondary);
 }
 
 :root {
@@ -101,6 +103,7 @@
   --background-secondary: oklch(0.2931 0 0);
   --border-primary: oklch(0.3867 0 0);
   --border-secondary: oklch(0.5624 0 0);
+  --border-brand-tertiary: oklch(0.6392 0.1813 41.96);
   --text-tertiary: oklch(0.7668 0 0);
   --text-neutral-primary: oklch(0.9158 0 0);
   --text-neutral-secondary: oklch(0.8483 0 0);
@@ -108,6 +111,7 @@
   --text-brand-tertiary: oklch(0.6392 0.1813 41.96);
   --icon-primary: oklch(100% 0.00011 271.152);
   --icon-neutral-primary: oklch(0.9158 0 0);
+  --icon-brand-secondary: oklch(0.7163 0.1862 43.29);
 }
 
 .dark {

--- a/src/components/SearchField.tsx
+++ b/src/components/SearchField.tsx
@@ -1,14 +1,34 @@
+import { cn } from '@/lib/utils';
 import { SearchIcon } from 'lucide-react';
 
 export default function SearchField() {
   return (
-    <div className="outline-brand/80 flex w-fit items-center rounded-full px-4 py-2 focus-within:gap-4 focus-within:outline-2">
+    <div
+      className={cn([
+        'group/search flex items-center gap-4',
+        'bg-background-primary w-4/5 px-4 py-2',
+        'border-border-secondary rounded-full border',
+        'outline-border-brand-tertiary',
+        'hover:bg-background-primary-hover',
+        'focus-within:border-border-brand-tertiary focus-within:outline',
+        'transition-all',
+      ])}
+    >
       <label htmlFor="search">
-        <SearchIcon size={18} />
+        <SearchIcon
+          className="stroke-icon-primary group-focus-within/search:stroke-icon-brand-secondary"
+          size={18}
+        />
       </label>
       <input
         id="search"
-        className="w-0 grow opacity-0 transition-all duration-500 focus:w-[280px] focus:opacity-100 focus-visible:outline-0"
+        className={cn([
+          'w-full',
+          'text-text-neutral-tertiary',
+          'hover:placeholder:text-text-tertiary',
+          'focus-visible:outline-0 focus-visible:placeholder:opacity-0',
+        ])}
+        placeholder="책 제목, 저자, 장르 검색"
       />
     </div>
   );

--- a/src/components/SearchField.tsx
+++ b/src/components/SearchField.tsx
@@ -1,106 +1,63 @@
 'use client';
 
-import { useDebounce } from '@/hooks/useDebounce';
 import { cn } from '@/lib/utils';
-import { useQuery } from '@tanstack/react-query';
 import { SearchIcon } from 'lucide-react';
-import { ChangeEventHandler, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ChangeEventHandler, useState } from 'react';
 
 interface Props {
   placeholder?: string;
 }
 
 export default function SearchField({ placeholder = '' }: Props) {
+  const router = useRouter();
   const [keyword, setKeyword] = useState('');
-  const [isOpen, setIsOpen] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const debouncedKeyword = useDebounce(keyword);
-
-  const {} = useQuery({
-    queryKey: ['search', debouncedKeyword],
-    queryFn: () => {
-      return keyword;
-    },
-    enabled: !!debouncedKeyword,
-    staleTime: 5 * 60 * 1000,
-  });
-
-  const handleFocus = () => {
-    if (keyword) {
-      setIsOpen(true);
-    } else {
-      setIsOpen(false);
-    }
-  };
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const nextKeyword = e.target.value;
-    setKeyword(nextKeyword);
-    if (!nextKeyword) {
-      setIsOpen(false);
-    } else {
-      setIsOpen(true);
-    }
+    setKeyword(e.target.value);
   };
 
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(e.target as Node)
-      ) {
-        setIsOpen(false);
-      }
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const _keyword = keyword.trim();
+    if (!_keyword || _keyword.length < 2) {
+      alert('검색어를 2글자 이상 입력해주세요.');
+      return;
     }
-    document.addEventListener('click', handleClickOutside);
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, []);
+    router.push(`/books/search?keyword=${_keyword}`);
+  };
 
   return (
-    <div className="relative w-4/5" ref={wrapperRef}>
-      <div
+    <form
+      className={cn([
+        'group/search flex items-center gap-4',
+        'bg-background-primary w-4/5 px-4 py-2',
+        'border-border-secondary rounded-full border',
+        'outline-border-brand-tertiary',
+        'hover:bg-background-primary-hover',
+        'focus-within:border-border-brand-tertiary focus-within:outline',
+        'transition-all',
+      ])}
+      onSubmit={handleSubmit}
+    >
+      <label htmlFor="search">
+        <SearchIcon
+          className="stroke-icon-primary group-focus-within/search:stroke-icon-brand-secondary"
+          size={18}
+        />
+      </label>
+      <input
+        id="search"
         className={cn([
-          'group/search flex items-center gap-4',
-          'bg-background-primary w-full px-4 py-2',
-          'border-border-secondary rounded-full border',
-          'outline-border-brand-tertiary',
-          'hover:bg-background-primary-hover',
-          'focus-within:border-border-brand-tertiary focus-within:outline',
-          'transition-all',
+          'w-full',
+          'text-text-neutral-tertiary',
+          'hover:placeholder:text-text-tertiary',
+          'focus-visible:outline-0 focus-visible:placeholder:opacity-0',
         ])}
-      >
-        <label htmlFor="search">
-          <SearchIcon
-            className="stroke-icon-primary group-focus-within/search:stroke-icon-brand-secondary"
-            size={18}
-          />
-        </label>
-        <input
-          id="search"
-          className={cn([
-            'w-full',
-            'text-text-neutral-tertiary',
-            'hover:placeholder:text-text-tertiary',
-            'focus-visible:outline-0 focus-visible:placeholder:opacity-0',
-          ])}
-          value={keyword}
-          onChange={handleChange}
-          onFocus={handleFocus}
-          placeholder={placeholder}
-        />
-      </div>
-      {isOpen ? (
-        <div
-          className={cn([
-            'absolute z-10',
-            'min-h-80 w-full',
-            'bg-background-primary rounded-2xl',
-            `translate-y-1`,
-          ])}
-        />
-      ) : null}
-    </div>
+        value={keyword}
+        onChange={handleChange}
+        placeholder={placeholder}
+      />
+    </form>
   );
 }

--- a/src/components/SearchField.tsx
+++ b/src/components/SearchField.tsx
@@ -1,35 +1,107 @@
-import { cn } from '@/lib/utils';
-import { SearchIcon } from 'lucide-react';
+'use client';
 
-export default function SearchField() {
+import { useDebounce } from '@/hooks/useDebounce';
+import { cn } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
+import { SearchIcon } from 'lucide-react';
+import { ChangeEventHandler, useEffect, useRef, useState } from 'react';
+
+interface Props {
+  placeholder?: string;
+  offset?: number;
+}
+
+export default function SearchField({ placeholder = '', offset = 0 }: Props) {
+  const [keyword, setKeyword] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const debouncedKeyword = useDebounce(keyword);
+
+  const {} = useQuery({
+    queryKey: ['search', debouncedKeyword],
+    queryFn: () => {
+      return keyword;
+    },
+    enabled: !!debouncedKeyword,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const handleFocus = () => {
+    if (keyword) {
+      setIsOpen(true);
+    } else {
+      setIsOpen(false);
+    }
+  };
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const nextKeyword = e.target.value;
+    setKeyword(nextKeyword);
+    if (!nextKeyword) {
+      setIsOpen(false);
+    } else {
+      setIsOpen(true);
+    }
+  };
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, []);
+
   return (
-    <div
-      className={cn([
-        'group/search flex items-center gap-4',
-        'bg-background-primary w-4/5 px-4 py-2',
-        'border-border-secondary rounded-full border',
-        'outline-border-brand-tertiary',
-        'hover:bg-background-primary-hover',
-        'focus-within:border-border-brand-tertiary focus-within:outline',
-        'transition-all',
-      ])}
-    >
-      <label htmlFor="search">
-        <SearchIcon
-          className="stroke-icon-primary group-focus-within/search:stroke-icon-brand-secondary"
-          size={18}
-        />
-      </label>
-      <input
-        id="search"
+    <div className="relative w-4/5" ref={wrapperRef}>
+      <div
         className={cn([
-          'w-full',
-          'text-text-neutral-tertiary',
-          'hover:placeholder:text-text-tertiary',
-          'focus-visible:outline-0 focus-visible:placeholder:opacity-0',
+          'group/search flex items-center gap-4',
+          'bg-background-primary w-full px-4 py-2',
+          'border-border-secondary rounded-full border',
+          'outline-border-brand-tertiary',
+          'hover:bg-background-primary-hover',
+          'focus-within:border-border-brand-tertiary focus-within:outline',
+          'transition-all',
         ])}
-        placeholder="책 제목, 저자, 장르 검색"
-      />
+      >
+        <label htmlFor="search">
+          <SearchIcon
+            className="stroke-icon-primary group-focus-within/search:stroke-icon-brand-secondary"
+            size={18}
+          />
+        </label>
+        <input
+          id="search"
+          className={cn([
+            'w-full',
+            'text-text-neutral-tertiary',
+            'hover:placeholder:text-text-tertiary',
+            'focus-visible:outline-0 focus-visible:placeholder:opacity-0',
+          ])}
+          value={keyword}
+          onChange={handleChange}
+          onFocus={handleFocus}
+          placeholder={placeholder}
+        />
+      </div>
+      {isOpen ? (
+        <div
+          className={cn([
+            'absolute z-10',
+            'min-h-80 w-full',
+            'bg-background-primary rounded-2xl',
+            `translate-y-${offset}`,
+          ])}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/SearchField.tsx
+++ b/src/components/SearchField.tsx
@@ -8,10 +8,9 @@ import { ChangeEventHandler, useEffect, useRef, useState } from 'react';
 
 interface Props {
   placeholder?: string;
-  offset?: number;
 }
 
-export default function SearchField({ placeholder = '', offset = 0 }: Props) {
+export default function SearchField({ placeholder = '' }: Props) {
   const [keyword, setKeyword] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -98,7 +97,7 @@ export default function SearchField({ placeholder = '', offset = 0 }: Props) {
             'absolute z-10',
             'min-h-80 w-full',
             'bg-background-primary rounded-2xl',
-            `translate-y-${offset}`,
+            `translate-y-1`,
           ])}
         />
       ) : null}

--- a/src/components/SearchField.tsx
+++ b/src/components/SearchField.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { cn } from '@/lib/utils';
 import { SearchIcon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { ChangeEventHandler, useState } from 'react';
+
+import { cn } from '@/lib/utils';
 
 interface Props {
   placeholder?: string;

--- a/src/components/SearchField.tsx
+++ b/src/components/SearchField.tsx
@@ -27,6 +27,8 @@ export default function SearchField({ placeholder = '' }: Props) {
     router.push(`/books/search?keyword=${_keyword}`);
   };
 
+  //https://image.aladin.co.kr/product/31424/4/spineflip/k482832219_d.jpg
+
   return (
     <form
       className={cn([

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay: number = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/lib/aladin.api.ts
+++ b/src/lib/aladin.api.ts
@@ -3,6 +3,36 @@ import { BookLookUpResponse } from '@/types/aladin.type';
 
 const key = process.env.ALADIN_API_TTBKEY;
 
+type FetchBookSearchType = {
+  query: string;
+  queryType?: 'Keyword' | 'Title' | 'Author' | 'Publisher';
+  start?: number;
+  maxResults?: number;
+};
+
+const fetchBookSearch = async ({
+  query,
+  queryType = 'Keyword',
+  start = 1,
+  maxResults = 10,
+}: FetchBookSearchType) => {
+  if (!key) throw new Error('ttfkey is not defined');
+  if (!query) throw new Error('query is not defined');
+
+  try {
+    const response = await fetch(
+      `/api/open/book/aladin/search?query=${encodeURIComponent(query)}&queryType=${queryType}&start=${start}&maxResults=${maxResults}`,
+    );
+    if (!response.ok) {
+      throw new Error(`알라딘 API 오류: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 const fetchBookDetailProxy = async (
   isbn: string,
 ): Promise<BookLookUpResponse | undefined> => {
@@ -75,6 +105,7 @@ async function fetchBookListProxy() {
 }
 
 export {
+  fetchBookSearch,
   fetchBookDetailProxy,
   fetchBookDetail,
   fetchBookListProxy,

--- a/src/lib/aladin.api.ts
+++ b/src/lib/aladin.api.ts
@@ -3,26 +3,32 @@ import { BookLookUpResponse } from '@/types/aladin.type';
 
 const key = process.env.ALADIN_API_TTBKEY;
 
-type FetchBookSearchType = {
+type FetchBookSearchProxyType = {
   query: string;
   queryType?: 'Keyword' | 'Title' | 'Author' | 'Publisher';
   start?: number;
   maxResults?: number;
 };
 
-const fetchBookSearch = async ({
+const fetchBookSearchProxy = async ({
   query,
   queryType = 'Keyword',
   start = 1,
   maxResults = 10,
-}: FetchBookSearchType) => {
-  if (!key) throw new Error('ttfkey is not defined');
+}: FetchBookSearchProxyType) => {
   if (!query) throw new Error('query is not defined');
 
   try {
-    const response = await fetch(
-      `/api/open/book/aladin/search?query=${encodeURIComponent(query)}&queryType=${queryType}&start=${start}&maxResults=${maxResults}`,
-    );
+    const baseUrl = '/api/open/book/aladin/search';
+    const apiParams = new URLSearchParams({
+      query,
+      queryType,
+      start: start.toString(),
+      maxResults: maxResults.toString(),
+    });
+
+    const response = await fetch(`${baseUrl}?${apiParams.toString()}`);
+
     if (!response.ok) {
       throw new Error(`알라딘 API 오류: ${response.status}`);
     }
@@ -105,7 +111,7 @@ async function fetchBookListProxy() {
 }
 
 export {
-  fetchBookSearch,
+  fetchBookSearchProxy,
   fetchBookDetailProxy,
   fetchBookDetail,
   fetchBookListProxy,

--- a/src/lib/aladin.api.ts
+++ b/src/lib/aladin.api.ts
@@ -1,5 +1,8 @@
-import { BookListResponse } from '@/mocks/mockBookList';
-import { BookLookUpResponse } from '@/types/aladin.type';
+import {
+  BookListResponse,
+  BookLookUpResponse,
+  BookSearchResponse,
+} from '@/types/aladin.type';
 
 const key = process.env.ALADIN_API_TTBKEY;
 
@@ -14,8 +17,8 @@ const fetchBookSearchProxy = async ({
   query,
   queryType = 'Keyword',
   start = 1,
-  maxResults = 10,
-}: FetchBookSearchProxyType) => {
+  maxResults = 12,
+}: FetchBookSearchProxyType): Promise<BookListResponse | undefined> => {
   if (!query) throw new Error('query is not defined');
 
   try {

--- a/src/mocks/mockBookList.ts
+++ b/src/mocks/mockBookList.ts
@@ -1,50 +1,3 @@
-type BookSearchResponse = {
-  title: string;
-  link: string;
-  author: string;
-  pubDate: string;
-  description: string;
-  isbn: string;
-  isbn13: string;
-  itemId: number;
-  priceSales: number;
-  priceStandard: number;
-  mallType: string;
-  stockStatus: string;
-  mileage: number;
-  cover: string;
-  categoryId: number;
-  categoryName: string;
-  publisher: string;
-  salesPoint: number;
-  adult: boolean;
-  fixedPrice: boolean;
-  customerReviewRank: number;
-  bestDuration?: string;
-  bestRank: number;
-  seriesInfo?: {
-    seriesId: number;
-    seriesLink: string;
-    seriesName: string;
-  };
-  subInfo: {};
-};
-
-type BookListResponse = {
-  version: string;
-  logo: string;
-  title: string;
-  link: string;
-  pubDate: string;
-  totalResults: number;
-  startIndex: number;
-  itemsPerPage: number;
-  query: string;
-  searchCategoryId: number;
-  searchCategoryName: string;
-  item: BookSearchResponse[];
-};
-
 const mockBookList = {
   version: '20131101',
   logo: 'http://image.aladin.co.kr/img/header/2011/aladin_logo_new.gif',
@@ -366,5 +319,4 @@ const mockBookList = {
   ],
 };
 
-export type { BookSearchResponse, BookListResponse };
 export { mockBookList };

--- a/src/types/aladin.type.ts
+++ b/src/types/aladin.type.ts
@@ -3,6 +3,53 @@
 https://docs.google.com/document/d/1mX-WxuoGs8Hy-QalhHcvuV17n50uGI2Sg_GHofgiePE/edit?tab=t.0#heading=h.wzyr9o7mof2u 
 */
 
+type BookSearchResponse = {
+  title: string;
+  link: string;
+  author: string;
+  pubDate: string;
+  description: string;
+  isbn: string;
+  isbn13: string;
+  itemId: number;
+  priceSales: number;
+  priceStandard: number;
+  mallType: string;
+  stockStatus: string;
+  mileage: number;
+  cover: string;
+  categoryId: number;
+  categoryName: string;
+  publisher: string;
+  salesPoint: number;
+  adult: boolean;
+  fixedPrice: boolean;
+  customerReviewRank: number;
+  bestDuration?: string;
+  bestRank: number;
+  seriesInfo?: {
+    seriesId: number;
+    seriesLink: string;
+    seriesName: string;
+  };
+  subInfo: {};
+};
+
+type BookListResponse = {
+  version: string;
+  logo: string;
+  title: string;
+  link: string;
+  pubDate: string;
+  totalResults: number;
+  startIndex: number;
+  itemsPerPage: number;
+  query: string;
+  searchCategoryId: number;
+  searchCategoryName: string;
+  item: BookSearchResponse[];
+};
+
 type BookLookUpResponse = {
   adult: boolean; //성인작품 여부
   author: string; //저자명
@@ -37,4 +84,4 @@ type BookLookUpResponse = {
   title: string; //상품명
 };
 
-export type { BookLookUpResponse };
+export type { BookSearchResponse, BookListResponse, BookLookUpResponse };


### PR DESCRIPTION
# [Feat] SearchField 컴포넌트 구현 및 책 검색 페이지 구현

## SearchField 컴포넌트 구현

### 스타일

검색창은 25.12.28 기준 피그마와 동일한 디자인으로 구현

검색창의 너비는 PageComponent의 content 영역 너비의 80%로 설정함

### 기능

검색창에 텍스트를 입력한 후 submit하면 해당 텍스트와 연관된 도서를 aladin api를 통해 받아와 보여줌

텍스트가 존재하며 길이가 2 이상일 때만 submit할 수 있음

### 기타

원래는 suggestion 기능도 넣을려고 했는데, 할단된 api 한도가 너무 적어서 안 하기로 함

